### PR TITLE
Update .eslintrc.js

### DIFF
--- a/simple-typescript-node/.eslintrc.js
+++ b/simple-typescript-node/.eslintrc.js
@@ -14,5 +14,7 @@ module.exports = {
         sourceType: 'module',
     },
     plugins: ['@typescript-eslint'],
-    rules: {},
+    rules: {
+        '@typescript-eslint/interface-name-prefix': [0],
+    },
 };


### PR DESCRIPTION
Propose to do not require all interface names to be prefixed with I (interface-name-prefix)